### PR TITLE
Remove key discovery card from company types section

### DIFF
--- a/customer-data-analysis-dashboard.html
+++ b/customer-data-analysis-dashboard.html
@@ -1357,11 +1357,6 @@
                 <p class="section-subtitle">Performance Comparison & Strategic Insights</p>
             </div>
 
-            <div class="highlight-box">
-                <div class="highlight-title">Key Discovery</div>
-                <p>Firms deliver 38% higher lifetime value than Individuals (£273 vs £198) despite comprising only 13.8% of the customer base. Partnerships show exceptional 75% retention but shortest tenure.</p>
-            </div>
-
             <div class="stats-grid">
                 <div class="stat-card">
                     <div class="stat-value">84.2%</div>


### PR DESCRIPTION
## Summary
- remove the key discovery highlight card from the Company Types Analysis section of the dashboard

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4069e3da88321bdeeb4475faca949