### PR TITLE
Remove opportunity column from scalable opportunities table

### DIFF
--- a/customer-data-analysis-dashboard.html
+++ b/customer-data-analysis-dashboard.html
@@ -1634,7 +1634,6 @@
                             <th>LTV</th>
                             <th>Customers</th>
                             <th>Total Value</th>
-                            <th>Opportunity</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -1643,56 +1642,48 @@
                             <td>£464</td>
                             <td>87</td>
                             <td>£40,332</td>
-                            <td><span class="badge badge-growth">Strong Growth</span></td>
                         </tr>
                         <tr>
                             <td class="top-performer">Firm + Team Building + Direct</td>
                             <td>£460</td>
                             <td>109</td>
                             <td>£50,153</td>
-                            <td><span class="badge badge-premium">Market Leader</span></td>
                         </tr>
                         <tr>
                             <td>Firm + Public Speaking + Via Introducer</td>
                             <td>£455</td>
                             <td>111</td>
                             <td>£50,516</td>
-                            <td><span class="badge badge-stable">Partner Channel</span></td>
                         </tr>
                         <tr>
                             <td>Firm + Talent Management + Via Introducer</td>
                             <td>£451</td>
                             <td>83</td>
                             <td>£37,411</td>
-                            <td>B2B Focus</td>
                         </tr>
                         <tr>
                             <td>Firm + Appreciative Inquiry + Via Introducer</td>
                             <td>£436</td>
                             <td>51</td>
                             <td>£22,236</td>
-                            <td>Niche Leader</td>
                         </tr>
                         <tr>
                             <td>Individual + Public Speaking + Via Introducer</td>
                             <td>£431</td>
                             <td>149</td>
                             <td>£64,219</td>
-                            <td>Volume Play</td>
                         </tr>
                         <tr>
                             <td>Firm + Psychometric Assessment + Via Introducer</td>
                             <td>£425</td>
                             <td>158</td>
                             <td>£67,150</td>
-                            <td>Corporate Market</td>
                         </tr>
                         <tr>
                             <td>Individual + Team Building + Via Introducer</td>
                             <td>£414</td>
                             <td>163</td>
                             <td>£67,482</td>
-                            <td>Scale Opportunity</td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
## Summary
- remove the Opportunity column from the Scalable High-Value Opportunities table on the customer dashboard

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d40d6e8d5483219d54232c70006cd6