### PR TITLE
Remove Peak Years column from declining introducers table

### DIFF
--- a/customer-data-analysis-dashboard.html
+++ b/customer-data-analysis-dashboard.html
@@ -1923,7 +1923,6 @@
                             <th>Historical (2019-22)</th>
                             <th>Recent (2023-25)</th>
                             <th>Decline</th>
-                            <th>Peak Years</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -1932,49 +1931,42 @@
                             <td>70 customers</td>
                             <td>0 customers</td>
                             <td><strong style="color: red;">-100%</strong></td>
-                            <td>Completely stopped</td>
                         </tr>
                         <tr>
                             <td><strong>Hippocrates Health Institute</strong></td>
                             <td>74 customers</td>
                             <td>4 customers</td>
                             <td><strong style="color: red;">-92.8%</strong></td>
-                            <td>2019-2020 peak</td>
                         </tr>
                         <tr>
                             <td><strong>SWA - Spiritual Workers</strong></td>
                             <td>103 customers</td>
                             <td>20 customers</td>
                             <td><strong style="color: var(--primary-coral);">-74.1%</strong></td>
-                            <td>Strong 2019-2021</td>
                         </tr>
                         <tr>
                             <td><strong>Be-A Education - Nail Tech</strong></td>
                             <td>99 customers</td>
                             <td>22 customers</td>
                             <td><strong style="color: var(--primary-coral);">-70.4%</strong></td>
-                            <td>Peak 2020</td>
                         </tr>
                         <tr>
                             <td><strong>Association for Coaching</strong></td>
                             <td>134 customers</td>
                             <td>32 customers</td>
                             <td><strong style="color: var(--primary-coral);">-68.2%</strong></td>
-                            <td>Still #9 revenue</td>
                         </tr>
                         <tr>
                             <td><strong>Blossom & Berry</strong></td>
                             <td>97 customers</td>
                             <td>25 customers</td>
                             <td><strong style="color: var(--primary-coral);">-65.6%</strong></td>
-                            <td>Baby massage niche</td>
                         </tr>
                         <tr>
                             <td><strong>APDO-UK (non-member)</strong></td>
                             <td>126 customers</td>
                             <td>33 customers</td>
                             <td><strong style="color: var(--primary-coral);">-65.1%</strong></td>
-                            <td>Member version strong</td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
## Summary
- remove the Peak Years column from the Declining Introducers table on the customer data analysis dashboard
- update each table row to omit the former Peak Years data cells

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d40e6687c48321aeca2487de1cbfd3