### PR TITLE
Update revenue chart labeling

### DIFF
--- a/customer-data-analysis-dashboard.html
+++ b/customer-data-analysis-dashboard.html
@@ -373,6 +373,20 @@
             margin-bottom: 1rem;
             text-align: center;
         }
+
+        .chart-description {
+            font-size: 0.9rem;
+            color: var(--text-light);
+            text-align: center;
+            margin-bottom: 1rem;
+        }
+
+        .chart-note {
+            font-size: 0.8rem;
+            color: var(--text-light);
+            text-align: center;
+            margin-top: 1rem;
+        }
         
         /* Key Insights */
         .insight-box {
@@ -688,8 +702,10 @@
             </div>
 
             <div class="chart-container">
-                <div class="chart-title">Revenue Trends Over Time</div>
+                <div class="chart-title">WI Revenue per Policy Overtime</div>
+                <div class="chart-description">policy fee + WI comm, taken per policy.</div>
                 <canvas id="revenueChart"></canvas>
+                <div class="chart-note">Data leftward skew consideration - average policy rev per customer, attributed to join date of that customer, resulting in a leftward skew in the graph.</div>
             </div>
 
             <div class="card">


### PR DESCRIPTION
## Summary
- rename the revenue chart heading to "WI Revenue per Policy Overtime"
- add descriptive context about the revenue components and leftward skew directly around the chart

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d42aea66e08321be532d345dbe2bf5