### PR TITLE
Increase spacing after revenue chart

### DIFF
--- a/customer-data-analysis-dashboard.html
+++ b/customer-data-analysis-dashboard.html
@@ -365,6 +365,10 @@
             border-radius: 10px;
             box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
         }
+
+        .chart-container.extra-bottom-spacing {
+            margin-bottom: 4rem;
+        }
         
         .chart-title {
             font-size: 1.2rem;
@@ -701,7 +705,7 @@
                 </table>
             </div>
 
-            <div class="chart-container">
+            <div class="chart-container extra-bottom-spacing">
                 <div class="chart-title">WI Revenue per Policy Overtime</div>
                 <div class="chart-description">policy fee + WI comm, taken per policy.</div>
                 <canvas id="revenueChart"></canvas>


### PR DESCRIPTION
## Summary
- add a utility class to provide extra bottom spacing for charts when needed
- apply the new spacing class to the WI Revenue per Policy Overtime chart to prevent overlap with the following section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d42d4d82b8832193904f37237157b0